### PR TITLE
Update pattern.relateditems.less

### DIFF
--- a/mockup/patterns/relateditems/pattern.relateditems.less
+++ b/mockup/patterns/relateditems/pattern.relateditems.less
@@ -38,7 +38,7 @@
   font-size: 12px;
   border: 1px solid #aaa;
   border-bottom-style: none;
-  z-index: 999;
+  z-index: 4;
   position: relative;
   padding: 0 6px;
   color: #333;


### PR DESCRIPTION
The position of the widget related items (z-index) is high in relation to the added content menu.
